### PR TITLE
Changed behaviour to allow .template files in phar

### DIFF
--- a/box.json
+++ b/box.json
@@ -6,7 +6,7 @@
   ],
   "finder": [
     {
-      "name": ["*.php", "*.xsd", "*.yml", "*.xml", "*.dist", "LICENSE", "LICENSE.md"],
+      "name": ["*.php", "*.template", "*.xsd", "*.yml", "*.xml", "*.dist", "LICENSE", "LICENSE.md"],
       "exclude": ["Tests", "tests", "*.feature", "*.dat", "*.exe", "*.bin"],
       "in": "vendor"
     }


### PR DESCRIPTION
because phpspec uses them to have a default class, specification and method template if it is not defined project based